### PR TITLE
Allow config from env variables

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,44 +5,20 @@ jobs:
     name: build, pack & publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+    - name: Setup .NET environment
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
 
-      # - name: Setup dotnet
-      #   uses: actions/setup-dotnet@v1
-      #   with:
-      #     dotnet-version: 3.1.200
+    - name: Build project
+      run: dotnet build -c Release
+    
+    - name: Run Unit Tests
+      run: dotnet test
 
-      # Publish
-      - name: publish on version change
-        id: publish_nuget
-        uses: rohith/publish-nuget@v2
-        with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
-          
-          # NuGet package id, used for version detection & defaults to project name
-          PACKAGE_NAME: MhLabs.WebApi.Observability
-          
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          # VERSION_FILE_PATH: Directory.Build.props
+    - name: Generate a NuGet package
+      run: dotnet pack --no-build -c Release -o .
 
-          # Regex pattern to extract version info in a capturing group
-          VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-          
-          # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
-          # VERSION_STATIC: 1.0.0
-
-          # Flag to toggle git tagging, enabled by default
-          # TAG_COMMIT: true
-
-          # Format of the git tag, [*] gets replaced with actual version
-          # TAG_FORMAT: v*
-
-          # API key to authenticate with NuGet server
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          # NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # INCLUDE_SYMBOLS: false
+    - name: Push to GitHub Package Registry
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,4 +30,4 @@ jobs:
       run: dotnet pack --no-build -c Release -o .
 
     - name: Push to GitHub Package Registry
-      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json -n true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup .NET environment
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: 3.1.200
 
     - name: Build project
       run: dotnet build -c Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,4 +21,4 @@ jobs:
       run: dotnet pack --no-build -c Release -o .
 
     - name: Push to GitHub Package Registry
-      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,14 @@
 name: publish to nuget
-on: push
+
+on: 
+  push:
+    branches:
+      - '*'
+      - '!main'
+      - '!master'
+      - '!develop'
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+
 jobs:
   publish:
     name: build, pack & publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,5 @@
 name: publish to nuget
-on:
-  push:
-    branches:
-      - master # Default release branch
+on: push
 jobs:
   publish:
     name: build, pack & publish

--- a/MhLabs.WebApi.Observability/Framework/Logging/SerilogFactory.cs
+++ b/MhLabs.WebApi.Observability/Framework/Logging/SerilogFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using MhLabs.SerilogExtensions;
+using Microsoft.Extensions.Configuration;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -15,7 +16,11 @@ namespace MhLabs.WebApi.Observability.Framework.Logging
         internal static ILogger Create()
         {
             Serilog.Debugging.SelfLog.Enable(Console.Error);
-            
+
+            IConfiguration config = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
+
             return Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Information()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
@@ -31,6 +36,8 @@ namespace MhLabs.WebApi.Observability.Framework.Logging
                 .Enrich.With<RouteTemplateEnrichment>()
                 .Enrich.WithProperty("Stack", Settings.Stack)
                 .WriteTo.Console(new MhLabsCompactJsonFormatter())
+                .ReadFrom
+                .Configuration(config)
                 .CreateLogger();
         }
 

--- a/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
+++ b/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.1.0-beta02</Version>
+    <Version>3.1.0-beta03</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>MhLabs.WebApi.Observability</PackageId>
     <IsPackable>true</IsPackable>

--- a/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
+++ b/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>3.1.0-beta01</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>MhLabs.WebApi.Observability</PackageId>
+    <IsPackable>true</IsPackable>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RepositoryUrl>https://github.com/mhlabs/MhLabs.WebApi.Observability</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
+++ b/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.0.1</Version>
+    <Version>3.1.0-beta01</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
+++ b/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0-beta02</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>MhLabs.WebApi.Observability</PackageId>
     <IsPackable>true</IsPackable>

--- a/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
+++ b/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.1.0-beta03</Version>
+    <Version>3.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>MhLabs.WebApi.Observability</PackageId>
     <IsPackable>true</IsPackable>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # MhLabs.WebApi.Observability
+
+## Pushing a new version
+Set the `Version` number in the <a href="https://github.com/mhlabs/MhLabs.WebApi.Observability/blob/master/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj"> .csproj-file</a> before pushing. If an existing version is pushed the <a href="https://github.com/mhlabs/MhLabs.WebApi.Observability/actions">build will fail</a>.
+
+## Publish pre-release packages on branches to allow us to test the package without merging to master
+1. Create a new branch
+2. Update `Version` number and add `-beta` postfix (can have .1, .2 etc. at the end)
+3. Make any required changes updating the version as you go
+4. Test beta package in solution that uses package
+5. Create PR and get it reviewed
+6. Check if there are any changes on the branch you're merging into. If there are you need to rebase those changes into yours and check that it still builds
+7. As the final thing before merging update version number and remove post fix

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # MhLabs.WebApi.Observability
 
+## Configure log levels in a lambda
+To change the log level in a lambda set the Serilog__MinimumLevel environment variable to the desired level, see example below. Please note that when running on Windows the environment variable name should be `Serilog:MinimumLevel`
+
+```
+  MyLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Timeout: 10
+      CodeUri: ./my_lambda_project
+      Handler: my_lambda_project::my_lambda_project.Functions.MyFunction::FunctionHandler
+      Environment:
+        Variables:
+          Serilog__MinimumLevel: Debug
+```
+
 ## Pushing a new version
 Set the `Version` number in the <a href="https://github.com/mhlabs/MhLabs.WebApi.Observability/blob/master/MhLabs.WebApi.Observability/MhLabs.WebApi.Observability.csproj"> .csproj-file</a> before pushing. If an existing version is pushed the <a href="https://github.com/mhlabs/MhLabs.WebApi.Observability/actions">build will fail</a>.
 


### PR DESCRIPTION
When configuring logger also take environment variables into account, allowing us to easily switch log levels for a lambda by adding the environment variable `Serilog__MinimumLevel: Debug`

Also updated the nuget publish workflow as it was failing and it was not easy to publish a pre-release version